### PR TITLE
Add extra kubelet and API metrics + region metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Coralogix Opentelemetry Integration
 
-### v0.1.0 / 2023-06-19
-* [FEATURE] initial version
+### v0.3.0 / 2023-07-12
+* [FEATURE] Adding extra kubelet and kubernetes API metrics
+* [FEATURE] Adding region detection
+* [CHORE] Update OpenTelemetry charts to 0.62.2
 
 ### v0.2.0 / 2023-06-19
-* [FEATURE] adding cluster name
+* [FEATURE] Adding cluster name
+
+### v0.1.0 / 2023-06-19
+* [FEATURE] Initial version

--- a/charts/Chart.lock
+++ b/charts/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.60.0
+  version: 0.62.2
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.60.0
-digest: sha256:561c61c1a30b993dd154c6d08ccfc114675d4fad76a3e6515b6a1a9fbf4bc7db
-generated: "2023-06-19T09:21:11.869902+01:00"
+  version: 0.62.2
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 5.8.1
+digest: sha256:0b4138d76d8d4d8e24aaeba9c494b27ca1fb2ce7984f79de90e5b0c8365b1c4d
+generated: "2023-07-12T09:52:49.16164+02:00"

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.2.0
+version: 0.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector
@@ -11,12 +11,12 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-collector-agent
-    version: "0.60.0"
+    version: "0.62.2"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-collector-events
-    version: "0.60.0"
+    version: "0.62.2"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector-events.enabled
   - name: kube-state-metrics

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -19,6 +19,10 @@ dependencies:
     version: "0.60.0"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector-events.enabled
+  - name: kube-state-metrics
+    version: "5.8.1"
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: kube-state-metrics.enabled
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
 maintainers:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -38,6 +38,25 @@ opentelemetry-collector-agent:
     kubeletMetrics:
       enabled: true
 
+  # Extra role rules are required in order to fetch kubelet and kuberenetes API metrics.
+  clusterRole:
+    rules:
+    - apiGroups:
+        - ""
+      resources:
+        - nodes
+        - nodes/proxy
+        - nodes/metrics
+        - configmaps
+      verbs:
+        - get
+        - list
+        - watch
+    - nonResourceURLs:
+        - "/metrics"
+      verbs:
+        - get
+    
   config:
     extensions:
       k8s_observer:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -53,6 +53,52 @@ opentelemetry-collector-agent:
             rule: type == "port" && port == 8080 && pod.name contains "kube-state-metrics" 
             config:
               endpoint: '`endpoint`'
+      prometheus/kubelet_extra_metrics:
+        config:
+          scrape_configs:
+          - job_name: kubernetes-cadvisor
+            honor_timestamps: true
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            metrics_path: /metrics/cadvisor
+            scheme: https
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            kubernetes_sd_configs:
+            - role: node
+            relabel_configs:
+              - action: labelmap
+                regex: __meta_kubernetes_node_label_(.+)
+              - target_label: __address__
+                replacement: kubernetes.default.svc.cluster.local:443
+              - source_labels: [__meta_kubernetes_node_name]
+                regex: (.+)
+                target_label: __metrics_path__
+                replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
+          - job_name: kubernetes-kubelet
+            honor_timestamps: true
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            metrics_path: /metrics
+            scheme: https
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            kubernetes_sd_configs:
+            - role: node
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - target_label: __address__
+              replacement: kubernetes.default.svc.cluster.local:443
+            - target_label: __metrics_path__
+              source_labels: [__meta_kubernetes_node_name]
+              regex: (.+)
+              replacement: /api/v1/nodes/$$1/proxy/metrics
+
 
     processors:
       resourcedetection/env:
@@ -107,6 +153,11 @@ opentelemetry-collector-agent:
               - kube_node_info
               - kube_pod_status_reason
               - kube_pod_status_qos_class
+              - kubernetes_build_info
+              - container_fs_writes_total
+              - container_fs_writes_bytes_total
+              - container_fs_reads_total
+              - container_fs_reads_bytes_total
 
     exporters:
       coralogix:
@@ -154,6 +205,7 @@ opentelemetry-collector-agent:
             - prometheus
             - hostmetrics
             - receiver_creator/ksm_prometheus
+            - prometheus/kubelet_extra_metrics
 
 opentelemetry-collector-events:
   enabled: true

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -59,6 +59,22 @@ opentelemetry-collector-agent:
         detectors: ["system", "env"]
         timeout: 2s
         override: false
+      resourcedetection/region:
+        detectors: ["gcp", "ec2"]
+        timeout: 2s
+        override: false
+        gcp:
+          resource_attributes:
+            cloud.region:
+              enabled: true
+            cloud.availability_zone:
+              enabled: true
+        ec2:
+          resource_attributes:
+            cloud.region:
+              enabled: true
+            cloud.availability_zone:
+              enabled: true
       metricstransform:
         transforms:
           include: .*
@@ -73,6 +89,8 @@ opentelemetry-collector-agent:
           include:
             match_type: strict
             metric_names:
+              - cloud.region
+              - cloud.availability_zone
               - k8s.pod.cpu.time
               - k8s.node.cpu.utilization
               - k8s.pod.cpu.utilization
@@ -127,6 +145,7 @@ opentelemetry-collector-agent:
             - filter/metrics
             - k8sattributes
             - resourcedetection/env
+            - resourcedetection/region
             - metricstransform
             - memory_limiter
             - batch

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -154,8 +154,6 @@ opentelemetry-collector-agent:
           include:
             match_type: strict
             metric_names:
-              - cloud.region
-              - cloud.availability_zone
               - k8s.pod.cpu.time
               - k8s.node.cpu.utilization
               - k8s.pod.cpu.utilization
@@ -303,3 +301,10 @@ opentelemetry-collector-events:
 kube-state-metrics:
   enabled: true
   prometheusScrape: false
+  collectors:
+    - pods
+    - nodes
+  metricsAllowList:
+    - kube_node_info
+    - kube_pod_status_reason
+    - kube_pod_status_qos_class

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -39,6 +39,21 @@ opentelemetry-collector-agent:
       enabled: true
 
   config:
+    extensions:
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${env:K8S_NODE_NAME}
+        observe_pods: true
+
+    receivers:
+      receiver_creator/ksm_prometheus:
+        watch_observers: [k8s_observer]
+        receivers:
+          prometheus_simple:
+            rule: type == "port" && port == 8080 && pod.name contains "kube-state-metrics" 
+            config:
+              endpoint: '`endpoint`'
+
     processors:
       resourcedetection/env:
         detectors: ["system", "env"]
@@ -71,6 +86,9 @@ opentelemetry-collector-agent:
               - system.network.io
               - container.cpu.utilization
               - container.cpu.time
+              - kube_node_info
+              - kube_pod_status_reason
+              - kube_pod_status_qos_class
 
     exporters:
       coralogix:
@@ -97,6 +115,10 @@ opentelemetry-collector-agent:
         logs:
           level: "{{ .Values.global.logLevel }}"
           encoding: json
+      extensions:
+      - k8s_observer
+      - health_check
+      - memory_ballast
       pipelines:
         metrics:
           exporters:
@@ -112,6 +134,7 @@ opentelemetry-collector-agent:
             - otlp
             - prometheus
             - hostmetrics
+            - receiver_creator/ksm_prometheus
 
 opentelemetry-collector-events:
   enabled: true
@@ -186,3 +209,7 @@ opentelemetry-collector-events:
             - resource/kube-events
           receivers:
             - k8sobjects
+
+kube-state-metrics:
+  enabled: true
+  prometheusScrape: false


### PR DESCRIPTION
# Description

This PR introduces few extra components to the chart, in order to enhance the Kubernetes dashboard experience for users, in particular:
- Introduces kube-state-metrics to obtain extra pod and node metrics
- Adds configuration to scrape metrics from kubelet, to obtain extra version information and container metrics (via cAdvisor)
- Adds resource detections for cloud providers to get region information.

Part of JIRA tickets PG-1237 and ES-47.

# How Has This Been Tested?

On a test cluster.

Testing region label is pending 

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
