### PR TITLE
Additional metrics k8s dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.4.0 / 2023-07-17
+* [FEATURE] Add additional k8s metrics to filter
+
 ### v0.3.0 / 2023-07-12
 * [FEATURE] Adding extra kubelet and kubernetes API metrics
 * [FEATURE] Adding region detection

--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ To destroy the local environment, you need to run the following command.
 ```bash
 make destroy
 ```
+
+## Note On Metrics Cardinality
+
+Please be aware that certain metrics collected by this agent have high cardinality, which means that the number of unique values for a given metric is high and might result in higher costs connected with metrics ingestion and storage. This is applies in particular to the pod related metrics `kube_pod_status_reason`, `kube_pod_status_phase` and `kube_pod_status_qos_class`.

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.3.0
+version: 0.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -142,11 +142,18 @@ opentelemetry-collector-agent:
           include:
             match_type: strict
             metric_names:
-              - k8s.pod.cpu.time
               - k8s.node.cpu.utilization
+              - k8s.node.allocatable_memory
+              - k8s.node.allocatable_cpu
+              - k8s.pod.cpu.time
               - k8s.pod.cpu.utilization
               - k8s.pod.network.io
               - k8s.pod.memory.usage
+              - k8s.pod.memory.available
+              - k8s.container.cpu_limit
+              - k8s.container.cpu_request
+              - k8s.container.memory_limit
+              - k8s.container.memory_request
               - system.cpu.time
               - system.disk.io
               - system.network.packets
@@ -157,6 +164,7 @@ opentelemetry-collector-agent:
               - container.cpu.time
               - kube_node_info
               - kube_pod_status_reason
+              - kube_pod_status_phase
               - kube_pod_status_qos_class
               - kubernetes_build_info
               - container_fs_writes_total
@@ -295,4 +303,5 @@ kube-state-metrics:
   metricsAllowList:
     - kube_node_info
     - kube_pod_status_reason
+    - kube_pod_status_phase
     - kube_pod_status_qos_class

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -137,6 +137,12 @@ opentelemetry-collector-agent:
             - action: add_label
               new_label: k8s.cluster.name
               new_value: "{{ .Values.global.clusterName }}"
+            - action: add_label
+              new_label: cx.otel_integration.name
+              new_value: "{{ .Chart.Name }}"
+            - action: add_label
+              new_label: cx.otel_integration.version
+              new_value: "{{ .Chart.Version }}"
       filter/metrics:
         metrics:
           include:


### PR DESCRIPTION
# Description

Resolves [PG-1237](https://coralogix.atlassian.net/browse/PG-1237) and [ES-58](https://coralogix.atlassian.net/browse/ES-58)

Adds additional metrics as requested by the team (container requests / limits, pod phase etc.) for the K8s dashboard.

Also adds attributes to mark our OTEL installation and version.

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[PG-1237]: https://coralogix.atlassian.net/browse/PG-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ES-58]: https://coralogix.atlassian.net/browse/ES-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ