### PR TITLE
Second round of improvements for K8s dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.6.0 / 2023-08-01
+* [FEATURE] Add `container_fs_usage_bytes` metric
+* [FEATURE] Add `k8s.node.name` resource attribute
+* [FEATURE] Override detection for cloud provider detectors
+* [CHORE] Update OpenTelemetry charts to 0.64.0
+
 ### v0.5.0 / 2023-07-26
 * [FEATURE] Add cluster metrics receiver
 

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.5.0
+version: 0.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector
@@ -11,12 +11,12 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-collector-agent
-    version: "0.62.2"
+    version: "0.64.0"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-collector-events
-    version: "0.62.2"
+    version: "0.64.0"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector-events.enabled
   - name: kube-state-metrics

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -15,6 +15,8 @@ opentelemetry-collector-agent:
         secretKeyRef:
           name: coralogix-opentelemetry-key
           key: PRIVATE_KEY
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "k8s.node.name=$(K8S_NODE_NAME)"
 
   presets:
     # Configures the Kubernetes Processor to add Kubernetes metadata.
@@ -115,7 +117,7 @@ opentelemetry-collector-agent:
       resourcedetection/region:
         detectors: ["gcp", "ec2"]
         timeout: 2s
-        override: false
+        override: true
         gcp:
           resource_attributes:
             cloud.region:
@@ -170,6 +172,7 @@ opentelemetry-collector-agent:
               - container_fs_writes_bytes_total
               - container_fs_reads_total
               - container_fs_reads_bytes_total
+              - container_fs_usage_bytes
 
     exporters:
       coralogix:


### PR DESCRIPTION
# Description

Another round of improvements required for the K8s dashboard feature. Includes:
- Adding (allow-listing) new filesystem metric from KSM
- Add K8s node name to resource attributes
- Enable for cloud provider resource detectors to override more generic system resource attributes
- Bumps upstream chart version

# How Has This Been Tested?
Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
