### PR TITLE
Re-add filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.7.0 / 2023-08-02
+* [FIX] Re-add metrics filtering
+* [CHORE] Remove unused `cx.otel_integration.version` attribute
+
 ### v0.6.0 / 2023-08-01
 * [FEATURE] Add `container_fs_usage_bytes` metric
 * [FEATURE] Add `k8s.node.name` resource attribute

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.6.0
+version: 0.7.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -142,9 +142,6 @@ opentelemetry-collector-agent:
             - action: add_label
               new_label: cx.otel_integration.name
               new_value: "{{ .Chart.Name }}"
-            - action: add_label
-              new_label: cx.otel_integration.version
-              new_value: "{{ .Chart.Version }}"
       filter/metrics:
         metrics:
           include:
@@ -208,6 +205,7 @@ opentelemetry-collector-agent:
           exporters:
             - coralogix
           processors:
+            - filter/metrics
             - k8sattributes
             - resourcedetection/env
             - resourcedetection/region
@@ -304,9 +302,6 @@ opentelemetry-collector-events:
             - action: add_label
               new_label: cx.otel_integration.name
               new_value: "{{ .Chart.Name }}"
-            - action: add_label
-              new_label: cx.otel_integration.version
-              new_value: "{{ .Chart.Version }}"
       filter/metrics:
         metrics:
           include:
@@ -351,6 +346,7 @@ opentelemetry-collector-events:
           exporters:
             - coralogix
           processors:
+            - filter/metrics
             - k8sattributes
             - resourcedetection/env
             - resourcedetection/region


### PR DESCRIPTION
# Description

Adds metrics filtering to the metrics pipeline, which has been previously accidentally removed. Also removes an unused attribute, which may cause high cardinality.

# How Has This Been Tested?

Locally.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
