### PR TITLE
Add allocatable metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.8.0 / 2023-08-03
+* [FEATURE] Add cluster metrics related to allocatable resources (CPU, memory)
+
 ### v0.7.0 / 2023-08-02
 * [FIX] Re-add metrics filtering
 * [CHORE] Remove unused `cx.otel_integration.version` attribute

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.7.0
+version: 0.8.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -260,6 +260,9 @@ opentelemetry-collector-events:
           - group: events.k8s.io
             mode: watch
             name: events
+      k8s_cluster:
+        collection_interval: 10s
+        allocatable_types_to_report: [cpu, memory]
 
     processors:
       resource/kube-events:


### PR DESCRIPTION
# Description

Overrides the cluster receiver preset and adds allocatable metrics (for CPU and memory), which are currently missing.

# How Has This Been Tested?

Locally.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [X] This change does not affect any particular component (e.g. it's CI or docs change)
