### PR TITLE
Move extra Kubernetes metrics to collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.9.0 / 2023-08-08
+* [FIX] Limit kube-state-metrics scraping to chart's instance only
+* [FIX] Move extra Kubernetes metrics to collector instead of agent
+* [FEATURE] Make `k8s.node.name` label the target node for Kubernetes node info metric
+
 ### v0.8.0 / 2023-08-03
 * [FEATURE] Add cluster metrics related to allocatable resources (CPU, memory)
 

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.8.0
+version: 0.9.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -132,7 +132,7 @@ opentelemetry-collector-agent:
               enabled: true
       metricstransform:
         transforms:
-          include: .*
+        - include: .*
           match_type: regexp
           action: update
           operations:
@@ -142,6 +142,14 @@ opentelemetry-collector-agent:
             - action: add_label
               new_label: cx.otel_integration.name
               new_value: "{{ .Chart.Name }}"
+        # Replace node name for kube node info with the name of the target node.
+        - include: kube_node_info
+          match_type: strict
+          action: update
+          operations:
+            - action: update_label
+              label: node
+              new_label: k8s.node.name
       filter/metrics:
         metrics:
           include:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -71,7 +71,7 @@ opentelemetry-collector-agent:
         watch_observers: [k8s_observer]
         receivers:
           prometheus_simple:
-            rule: type == "port" && port == 8080 && pod.name contains "kube-state-metrics" 
+            rule: type == "port" && port == 8080 && pod.name contains "{{ .Release.Name }}-kube-state-metrics" 
             config:
               endpoint: '`endpoint`'
       prometheus/kube_extra_metrics:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -39,25 +39,6 @@ opentelemetry-collector-agent:
     # Best used with mode = daemonset.
     kubeletMetrics:
       enabled: true
-
-  # Extra role rules are required in order to fetch kubelet and kuberenetes API metrics.
-  clusterRole:
-    rules:
-    - apiGroups:
-        - ""
-      resources:
-        - nodes
-        - nodes/metrics
-        - endpoints
-        - services
-      verbs:
-        - get
-        - list
-        - watch
-    - nonResourceURLs:
-        - "/metrics"
-      verbs:
-        - get
     
   config:
     extensions:
@@ -74,40 +55,6 @@ opentelemetry-collector-agent:
             rule: type == "port" && port == 8080 && pod.name contains "{{ .Release.Name }}-kube-state-metrics" 
             config:
               endpoint: '`endpoint`'
-      prometheus/kube_extra_metrics:
-        config:
-          scrape_configs:
-          - job_name: kubernetes-apiserver
-            honor_timestamps: true
-            scheme: https
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-            kubernetes_sd_configs:
-            - role: endpoints
-            relabel_configs:
-              - source_labels:
-                  [
-                    __meta_kubernetes_namespace,
-                    __meta_kubernetes_service_name,
-                    __meta_kubernetes_endpoint_port_name,
-                  ]
-                action: keep
-                regex: default;kubernetes;https
-          - job_name: kubernetes-cadvisor
-            honor_timestamps: true
-            metrics_path: /metrics/cadvisor
-            scheme: https
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-            kubernetes_sd_configs:
-            - role: node
-            relabel_configs:
-              - action: labelmap
-                regex: __meta_kubernetes_node_label_(.+)
 
     processors:
       resourcedetection/env:
@@ -172,12 +119,6 @@ opentelemetry-collector-agent:
               - kube_node_info
               - kube_pod_status_reason
               - kube_pod_status_qos_class
-              - kubernetes_build_info
-              - container_fs_writes_total
-              - container_fs_writes_bytes_total
-              - container_fs_reads_total
-              - container_fs_reads_bytes_total
-              - container_fs_usage_bytes
 
     exporters:
       coralogix:
@@ -225,7 +166,6 @@ opentelemetry-collector-agent:
             - prometheus
             - hostmetrics
             - receiver_creator/ksm_prometheus
-            - prometheus/kube_extra_metrics
 
 opentelemetry-collector-events:
   enabled: true
@@ -260,9 +200,58 @@ opentelemetry-collector-events:
       - apiGroups: ["", "events.k8s.io"]
         resources: ["events"]
         verbs: ["watch", "list"]
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+          - nodes/metrics
+          - endpoints
+          - services
+        verbs:
+          - get
+          - list
+          - watch
+      - nonResourceURLs:
+          - "/metrics"
+        verbs:
+          - get
 
   config:
     receivers:
+      prometheus/kube_extra_metrics:
+        config:
+          scrape_configs:
+          - job_name: kubernetes-apiserver
+            honor_timestamps: true
+            scheme: https
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+              - source_labels:
+                  [
+                    __meta_kubernetes_namespace,
+                    __meta_kubernetes_service_name,
+                    __meta_kubernetes_endpoint_port_name,
+                  ]
+                action: keep
+                regex: default;kubernetes;https
+          - job_name: kubernetes-cadvisor
+            honor_timestamps: true
+            metrics_path: /metrics/cadvisor
+            scheme: https
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            kubernetes_sd_configs:
+            - role: node
+            relabel_configs:
+              - action: labelmap
+                regex: __meta_kubernetes_node_label_(.+)
       k8sobjects:
         objects:
           - group: events.k8s.io
@@ -325,6 +314,12 @@ opentelemetry-collector-events:
               - k8s.container.cpu_request
               - k8s.container.memory_limit
               - k8s.container.memory_request
+              - kubernetes_build_info
+              - container_fs_writes_total
+              - container_fs_writes_bytes_total
+              - container_fs_reads_total
+              - container_fs_reads_bytes_total
+              - container_fs_usage_bytes
 
     exporters:
       coralogix:
@@ -367,6 +362,7 @@ opentelemetry-collector-events:
           receivers:
             - otlp
             - prometheus
+            - prometheus/kube_extra_metrics
             - k8s_cluster
         logs/kube-events:
           exporters:


### PR DESCRIPTION
# Description

Fixes mainly moving extra Kubernetes to collector instead of agent. Also improves KSM instance filtering and adjusts the node label for node info metrics.

# How Has This Been Tested?

Locally (on multi-node setup)

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
