### PR TITLE
Align integration name attribute with internal requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.10.0 / 2023-08-11
+* [FEATURE] Align the `cx.otel_integration.name` attribute with new internal requirements
+
 ### v0.9.0 / 2023-08-08
 * [FIX] Limit kube-state-metrics scraping to chart's instance only
 * [FIX] Move extra Kubernetes metrics to collector instead of agent

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.9.0
+version: 0.10.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -88,7 +88,7 @@ opentelemetry-collector-agent:
               new_value: "{{ .Values.global.clusterName }}"
             - action: add_label
               new_label: cx.otel_integration.name
-              new_value: "{{ .Chart.Name }}"
+              new_value: "coralogix-integration-helm"
         # Replace node name for kube node info with the name of the target node.
         - include: kube_node_info
           match_type: strict


### PR DESCRIPTION
# Description

The K8s dash-boarding feature requires us to have a uniform integration name attribute. This change is in order to align our integration name attributes to be `coralogix-integration-helm`.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
