### PR TITLE
feat: support host.id from system resource detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Coralogix Opentelemetry Integration
 
+### v0.11.0 / 2023-08-22
+
+* [FEATURE] Support host.id from system resource detector.
+
 ### v0.10.0 / 2023-08-11
 * [FEATURE] Align the `cx.otel_integration.name` attribute with new internal requirements
 

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -9,6 +9,22 @@ opentelemetry-collector-agent:
   enabled: true
   mode: daemonset
   fullnameOverride: coralogix-opentelemetry
+  extraVolumes:
+    - name: etcmachineid
+      hostPath:
+        path: /etc/machine-id
+    - name: varlibdbusmachineid
+      hostPath:
+        path: /var/lib/dbus/machine-id
+  extraVolumeMounts:
+    - mountPath: /etc/machine-id
+      mountPropagation: HostToContainer
+      name: etcmachineid
+      readOnly: true
+    - mountPath: /var/lib/dbus/machine-id
+      mountPropagation: HostToContainer
+      name: varlibdbusmachineid
+      readOnly: true
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -61,6 +77,10 @@ opentelemetry-collector-agent:
         detectors: ["system", "env"]
         timeout: 2s
         override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
       resourcedetection/region:
         detectors: ["gcp", "ec2"]
         timeout: 2s


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

For bare-metal use case we don't have `host.id`, which is required for k8s dashboard. The host.id is only coming from gcp / aws detectors. This PR changes to use the `system` detector's host.id detection.


<!-- (provide issue number, if applicable; otherwise remove) --> Fixes ES-70

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
