### PR TITLE
Change k8s.container.name to k8s.pod.name in subsystem attributes list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Coralogix Opentelemetry Integration
 
-### v0.11.0 / 2023-08-22
+### v0.12.0 / 2023-08-22
+* [FIX] Change `k8s.container.name` to `k8s.pod.name` attribute
 
+### v0.11.0 / 2023-08-22
 * [FEATURE] Support host.id from system resource detector.
 
 ### v0.10.0 / 2023-08-11

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coralogix-opentelemetry-integration
 description: OpenTelemetry barebones to have Coralogix Kubernetes Monitoring working out-of-the-box.
-version: 0.10.0
+version: 0.12.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - OpenTelemetry Collector

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -156,7 +156,7 @@ opentelemetry-collector-agent:
           - "k8s.daemonset.name"
           - "k8s.cronjob.name"
           - "k8s.job.name"
-          - "k8s.container.name"
+          - "k8s.pod.name"
           - "k8s.node.name"
           - "service.name"
 
@@ -357,7 +357,7 @@ opentelemetry-collector-events:
           - "k8s.daemonset.name"
           - "k8s.cronjob.name"
           - "k8s.job.name"
-          - "k8s.container.name"
+          - "k8s.pod.name"
           - "k8s.node.name"
           - "service.name"
 


### PR DESCRIPTION
# Description

We preferably want to include higher-level objects in the subsystem name (deployment, stateful set, pod etc.) instead of the container name, which is too specific. This small fix changes the container name attribute to pod name to pick correct attributes for pod.

# How Has This Been Tested?

Manually.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
