### PR TITLE
deprecate monitoring shipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Coralogix - Infrastructure Monitoring Integration
 
+> [!IMPORTANT]
+> Monitoring Shipper is deprecated and in maintenance mode. Please use [OpenTelemetry Integration](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm) project, which provides full OpenTelemetry observability solution.
+
 This repository contains the minimal OpenTelemetry barebones to have [Coralogix Kubernetes Monitoring](https://coralogix.com/docs/apm-kubernetes/) working out-of-the-box, ensuring only the required metrics are collected and shipped to the Coralogix Account.
 
 ![Kubernetes Dashboard](assets/kubernetes-dashboard.png)


### PR DESCRIPTION
# Description

Let's deprecate monitoring-shipper as recently I have received a couple of issues around it and the general recommendation is to use otel-integration

Fixes https://coralogix.atlassian.net/browse/ES-169

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
